### PR TITLE
Add cross-platform light/dark UI theming

### DIFF
--- a/src/jottr/main.py
+++ b/src/jottr/main.py
@@ -6,8 +6,8 @@ if sys.version_info < (3, 10):
 import os
 import json
 import hashlib
-from PyQt5.QtWidgets import (QApplication, QMainWindow, QTabWidget, QWidget, 
-                            QVBoxLayout, QHBoxLayout, QSplitter, QMenu, QToolBar, QAction, QStyle, QMessageBox, QFontDialog, QStyleFactory, QLabel, QDialog, QSizePolicy, QDialogButtonBox, QTabBar, QFileDialog, QShortcut, QToolButton)
+from PyQt5.QtWidgets import (QApplication, QMainWindow, QTabWidget, QWidget,
+                            QVBoxLayout, QHBoxLayout, QSplitter, QMenu, QToolBar, QAction, QMessageBox, QFontDialog, QStyleFactory, QLabel, QDialog, QSizePolicy, QDialogButtonBox, QTabBar, QFileDialog, QShortcut, QToolButton)
 from PyQt5.QtCore import Qt, QUrl, QTimer
 from PyQt5.QtWebEngineWidgets import QWebEngineView
 from editor_tab import EditorTab
@@ -24,7 +24,6 @@ from PyQt5.QtGui import QFont
 from PyQt5.QtSvg import QSvgRenderer
 from PyQt5.QtGui import QPainter
 from PyQt5.QtCore import QSize
-from PyQt5.QtGui import QPalette, QColor
 
 # Add vendor directory to path
 vendor_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'vendor')
@@ -39,15 +38,6 @@ APP_HOMEPAGE = "https://github.com/mfat/jottr"
 class TextEditorApp(QMainWindow):
     def __init__(self, file_path=None): 
         super().__init__()
-        
-        # Create settings manager first
-        self.settings_manager = SettingsManager()
-        
-        # Create snippet manager with settings manager
-        self.snippet_manager = SnippetManager(self.settings_manager)
-        
-        # Force light mode by setting a light palette and style
-        self.set_light_mode()
         
         # Load icons from Base64-encoded SVG data
         self.icons = {
@@ -90,12 +80,10 @@ class TextEditorApp(QMainWindow):
         self.setWindowTitle(APP_NAME)
         self.setGeometry(100, 100, 1200, 800)
         
-        # Initialize managers first
+        # Initialize managers and apply UI theme
         self.settings_manager = SettingsManager()
         self.snippet_manager = SnippetManager(self.settings_manager)
-        
-        # Force light mode by setting a light palette and style
-        self.set_light_mode()
+        self.apply_ui_theme(self.settings_manager.get_ui_theme())
         
         # Create toolbar first before styling
         self.toolbar = QToolBar("Main Toolbar")  # Add name here
@@ -146,29 +134,6 @@ class TextEditorApp(QMainWindow):
         
         self.setup_shortcuts()  # Add this line after setup_toolbar()
         
-    def set_light_mode(self):
-        """Force the application to use a light theme, ignoring the OS dark mode."""
-        # Set a light style (e.g., "Fusion" or "Windows")
-        QApplication.setStyle(QStyleFactory.create("Fusion"))
-        
-        # Create a light palette
-        palette = QPalette()
-        palette.setColor(QPalette.Window, QColor(240, 240, 240))  # Light gray background
-        palette.setColor(QPalette.WindowText, QColor(0, 0, 0))    # Black text
-        palette.setColor(QPalette.Base, QColor(255, 255, 255))    # White base
-        palette.setColor(QPalette.AlternateBase, QColor(240, 240, 240))  # Light gray alternate base
-        palette.setColor(QPalette.ToolTipBase, QColor(255, 255, 255))     # White tooltip background
-        palette.setColor(QPalette.ToolTipText, QColor(0, 0, 0))          # Black tooltip text
-        palette.setColor(QPalette.Text, QColor(0, 0, 0))                 # Black text
-        palette.setColor(QPalette.Button, QColor(240, 240, 240))         # Light gray buttons
-        palette.setColor(QPalette.ButtonText, QColor(0, 0, 0))          # Black button text
-        palette.setColor(QPalette.BrightText, QColor(255, 0, 0))         # Bright red text
-        palette.setColor(QPalette.Highlight, QColor(0, 120, 215))        # Blue highlight
-        palette.setColor(QPalette.HighlightedText, QColor(255, 255, 255))# White highlighted text
-        
-        # Apply the palette
-        QApplication.setPalette(palette)
-
     def setup_platform_style(self):
         """Apply platform-specific styling"""
         platform = sys.platform
@@ -603,9 +568,6 @@ class TextEditorApp(QMainWindow):
     def apply_ui_theme(self, theme):
         """Apply UI theme to application"""
         self.settings_manager.apply_ui_theme(theme)
-        
-        # Update all widgets
-        QApplication.setStyle(QStyleFactory.create(theme))
         self.update()
 
     def apply_theme(self, theme_name):

--- a/src/jottr/settings_dialog.py
+++ b/src/jottr/settings_dialog.py
@@ -1,9 +1,10 @@
-from PyQt5.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QLabel, 
+from PyQt5.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QLabel,
                             QLineEdit, QPushButton, QListWidget, QTabWidget,
                             QWidget, QCheckBox, QMessageBox, QInputDialog, QComboBox)
 from PyQt5.QtCore import Qt
 import json
 import os
+from ui_theme_manager import UIThemeManager
 
 class SettingsDialog(QDialog):
     def __init__(self, settings_manager, parent=None):
@@ -30,8 +31,8 @@ class SettingsDialog(QDialog):
         theme_layout = QHBoxLayout()
         theme_label = QLabel("UI Theme:")
         self.theme_combo = QComboBox()
-        self.theme_combo.addItems(['system', 'Fusion', 'Windows', 'Macintosh'])
-        self.theme_combo.setCurrentText(self.settings_manager.get_ui_theme())
+        self.theme_combo.addItems(UIThemeManager.available_themes())
+        self.theme_combo.setCurrentText(self.settings_manager.get_ui_theme().title())
         theme_layout.addWidget(theme_label)
         theme_layout.addWidget(self.theme_combo)
         appearance_layout.addLayout(theme_layout)
@@ -166,7 +167,7 @@ class SettingsDialog(QDialog):
             'homepage': self.homepage_edit.text(),
             'search_sites': self.get_search_sites(),
             'user_dictionary': self.get_user_dictionary(),
-            'ui_theme': self.theme_combo.currentText()
+            'ui_theme': self.theme_combo.currentText().lower()
         }
 
     def get_search_sites(self):

--- a/src/jottr/settings_manager.py
+++ b/src/jottr/settings_manager.py
@@ -2,8 +2,8 @@ import json
 import os
 from PyQt5.QtGui import QFont
 import time
-from PyQt5.QtWidgets import QApplication, QStyleFactory
 import sys
+from ui_theme_manager import UIThemeManager
 
 class SettingsManager:
     def __init__(self):
@@ -294,7 +294,7 @@ class SettingsManager:
 
     def get_ui_theme(self):
         """Get current UI theme setting"""
-        return self.settings.get('ui_theme', 'system')
+        return self.settings.get('ui_theme', 'light')
 
     def save_ui_theme(self, theme):
         """Save UI theme setting"""
@@ -303,12 +303,8 @@ class SettingsManager:
 
     def apply_ui_theme(self, theme):
         """Apply UI theme to application"""
-        if theme == 'system':
-            # Use system default theme
-            QApplication.setStyle(QStyleFactory.create('Fusion'))
-        else:
-            # Apply custom theme
-            QApplication.setStyle(QStyleFactory.create(theme))
-        
-        # Save the theme
-        self.save_ui_theme(theme) 
+        theme = (theme or 'light').lower()
+        if theme not in ('light', 'dark'):
+            theme = 'light'
+        UIThemeManager.apply_theme(theme)
+        self.save_ui_theme(theme)

--- a/src/jottr/ui_theme_manager.py
+++ b/src/jottr/ui_theme_manager.py
@@ -1,0 +1,45 @@
+from PyQt5.QtWidgets import QApplication, QStyleFactory
+from PyQt5.QtGui import QPalette, QColor
+
+
+class UIThemeManager:
+    """Manage application-wide UI themes."""
+
+    @staticmethod
+    def available_themes():
+        """Return list of supported UI themes."""
+        return ["Light", "Dark"]
+
+    @staticmethod
+    def apply_theme(theme_name: str):
+        """Apply the given theme to the QApplication."""
+        theme = (theme_name or "Light").lower()
+        QApplication.setStyle(QStyleFactory.create("Fusion"))
+        palette = QPalette()
+        if theme == "dark":
+            palette.setColor(QPalette.Window, QColor(53, 53, 53))
+            palette.setColor(QPalette.WindowText, QColor(255, 255, 255))
+            palette.setColor(QPalette.Base, QColor(35, 35, 35))
+            palette.setColor(QPalette.AlternateBase, QColor(53, 53, 53))
+            palette.setColor(QPalette.ToolTipBase, QColor(255, 255, 255))
+            palette.setColor(QPalette.ToolTipText, QColor(255, 255, 255))
+            palette.setColor(QPalette.Text, QColor(255, 255, 255))
+            palette.setColor(QPalette.Button, QColor(53, 53, 53))
+            palette.setColor(QPalette.ButtonText, QColor(255, 255, 255))
+            palette.setColor(QPalette.BrightText, QColor(255, 0, 0))
+            palette.setColor(QPalette.Highlight, QColor(142, 45, 197).lighter())
+            palette.setColor(QPalette.HighlightedText, QColor(0, 0, 0))
+        else:
+            palette.setColor(QPalette.Window, QColor(240, 240, 240))
+            palette.setColor(QPalette.WindowText, QColor(0, 0, 0))
+            palette.setColor(QPalette.Base, QColor(255, 255, 255))
+            palette.setColor(QPalette.AlternateBase, QColor(240, 240, 240))
+            palette.setColor(QPalette.ToolTipBase, QColor(255, 255, 255))
+            palette.setColor(QPalette.ToolTipText, QColor(0, 0, 0))
+            palette.setColor(QPalette.Text, QColor(0, 0, 0))
+            palette.setColor(QPalette.Button, QColor(240, 240, 240))
+            palette.setColor(QPalette.ButtonText, QColor(0, 0, 0))
+            palette.setColor(QPalette.BrightText, QColor(255, 0, 0))
+            palette.setColor(QPalette.Highlight, QColor(0, 120, 215))
+            palette.setColor(QPalette.HighlightedText, QColor(255, 255, 255))
+        QApplication.setPalette(palette)


### PR DESCRIPTION
## Summary
- introduce `UIThemeManager` with Fusion-based light and dark palettes
- allow settings and dialog to persist and select light/dark UI themes
- initialize main window using user-chosen theme for a modern look

## Testing
- `python -m pytest`
- `python -m py_compile src/jottr/ui_theme_manager.py src/jottr/settings_manager.py src/jottr/settings_dialog.py src/jottr/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b566c7d9dc832894f478f79aa2b489