### PR TITLE
Refactor editor layout panes

### DIFF
--- a/src/jottr/editor_tab.py
+++ b/src/jottr/editor_tab.py
@@ -7,8 +7,8 @@ if os.path.exists(vendor_dir):
     sys.path.insert(0, vendor_dir)
 
 from PyQt5.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QSplitter,
-                            QTextEdit, QListWidget, QInputDialog, QMenu, QFileDialog, QDialog,
-                            QToolBar, QAction, QCompleter, QListWidgetItem, QLineEdit, QPushButton, QMessageBox, QLabel, QShortcut, QToolTip)
+                            QTextEdit, QInputDialog, QMenu, QFileDialog, QDialog,
+                            QAction, QLineEdit, QPushButton, QMessageBox, QLabel, QShortcut, QToolTip)
 from PyQt5.QtCore import Qt, QUrl, QTimer, QStringListModel, QRegExp, QEvent
 from PyQt5.QtGui import (QTextCharFormat, QSyntaxHighlighter, QIcon, QFont, QKeySequence, 
                         QPainter, QPen, QColor, QFontMetrics, QTextDocument, QTextCursor)
@@ -20,6 +20,7 @@ import json
 import time
 from theme_manager import ThemeManager
 import hashlib
+from jottr.ui.editor_layout import EditorPane, SnippetPane, BrowserPane
 
 # Try enchant first, fallback to pyspellchecker
 try:
@@ -385,120 +386,50 @@ class EditorTab(QWidget):
         """Setup the UI components"""
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        
+
         # Create splitter for editor and side panes
         self.splitter = QSplitter(Qt.Horizontal)
-        
+
         # Create text editor with default font
         self.editor = CompletingTextEdit(self)  # Pass self as parent
         self.editor.setContextMenuPolicy(Qt.CustomContextMenu)
         self.editor.customContextMenuRequested.connect(self.show_context_menu)
         self.update_font(self.current_font)
-        
+
         # Connect text changed signal to update status
         self.editor.textChanged.connect(self.update_status)
-        
+
         # Create spell checker
         self.highlighter = SpellCheckHighlighter(self.editor.document(), self.settings_manager)
-        
-        # Add editor to splitter
-        self.splitter.addWidget(self.editor)
-        
-        # Create snippet widget
-        self.snippet_widget = QWidget()
-        snippet_layout = QVBoxLayout(self.snippet_widget)
-        snippet_layout.setContentsMargins(0, 0, 0, 0)
-        
-        # Snippet header
-        snippet_header = QWidget()
-        snippet_header.setFixedHeight(28)  # Match browser toolbar height
-        snippet_header.setStyleSheet("""
-            QWidget {
-                background-color: palette(window);
-                padding: 0px;
-                margin: 0px;
-            }
-            QPushButton {
-                border: none;
-                padding: 0px;
-                margin: 0px;
-                color: palette(text);
-            }
-            QPushButton:hover {
-                background-color: palette(highlight);
-                color: palette(highlighted-text);
-            }
-        """)
-        header_layout = QHBoxLayout(snippet_header)
-        header_layout.setContentsMargins(4, 2, 4, 2)  # Tight margins to match browser toolbar
-        header_layout.setSpacing(4)  # Reduce spacing between widgets
-        
-        snippet_title = QLabel("Snippets")
-        snippet_title.setStyleSheet("font-weight: bold; padding: 0px; margin: 0px;")
-        header_layout.addWidget(snippet_title)
-        
-        snippet_close = QPushButton("×")
-        snippet_close.setFixedSize(20, 20)
-        snippet_close.clicked.connect(lambda: self.toggle_pane("snippets"))
-        header_layout.addWidget(snippet_close)
-        
-        snippet_layout.addWidget(snippet_header)
-        
-        # Snippet list
-        self.snippet_list = QListWidget()
-        self.snippet_list.setStyleSheet("""
-            QListWidget {
-                border: none;
-                background-color: palette(base);
-            }
-            QListWidget::item {
-                padding: 4px;
-                border-radius: 2px;
-            }
-            QListWidget::item:selected {
-                background-color: palette(highlight);
-                color: palette(highlighted-text);
-            }
-            QListWidget::item:selected:hover {
-                background-color: palette(highlight);
-                color: palette(highlighted-text);
-            }
-            QListWidget::item:hover:!selected {
-                background-color: palette(alternate-base);
-            }
-        """)
-        self.snippet_list.itemDoubleClicked.connect(self.insert_snippet)
-        self.snippet_list.setContextMenuPolicy(Qt.CustomContextMenu)
-        self.snippet_list.customContextMenuRequested.connect(self.show_snippet_context_menu)
-        self.update_snippet_list()  # Populate the list
-        snippet_layout.addWidget(self.snippet_list)
-        
-        # Create browser widget without web view
-        self.browser_widget = QWidget()
-        browser_layout = QVBoxLayout(self.browser_widget)
-        browser_layout.setContentsMargins(0, 0, 0, 0)
-        browser_layout.setSpacing(0)
-        
-        # Create browser toolbar
-        self.setup_browser_toolbar()
-        
-        # Create placeholder for web view
-        self.web_container = QWidget()
-        web_container_layout = QVBoxLayout(self.web_container)  # Add layout
-        web_container_layout.setContentsMargins(0, 0, 0, 0)    # No margins
-        web_container_layout.setSpacing(0)                     # No spacing
-        browser_layout.addWidget(self.web_container)
-        
+
+        # Create the composable panes
+        self.editor_pane = EditorPane(self.editor, self)
+        self.snippet_pane = SnippetPane(self)
+        self.browser_pane = BrowserPane(self)
+
+        self.snippet_pane.close_requested.connect(lambda: self.toggle_pane("snippets"))
+        self.snippet_pane.snippet_activated.connect(self.insert_snippet)
+        self.snippet_pane.context_menu_requested.connect(self.show_snippet_context_menu)
+
+        self.browser_pane.close_requested.connect(lambda: self.toggle_pane("browser"))
+        self.browser_pane.navigate_requested.connect(self.navigate_to_url)
+        self.browser_pane.back_requested.connect(self.handle_browser_back)
+        self.browser_pane.forward_requested.connect(self.handle_browser_forward)
+
+        # Populate initial snippets
+        self.update_snippet_list()
+
         # Add widgets to splitter
-        self.splitter.addWidget(self.snippet_widget)
-        self.splitter.addWidget(self.browser_widget)
-        
+        self.splitter.addWidget(self.editor_pane)
+        self.splitter.addWidget(self.snippet_pane)
+        self.splitter.addWidget(self.browser_pane)
+
         # Add splitter to layout
         layout.addWidget(self.splitter)
-        
+
         # Hide side panes by default
-        self.snippet_widget.hide()
-        self.browser_widget.hide()
+        self.snippet_pane.hide()
+        self.browser_pane.hide()
         
         # Restore pane states
         states = self.settings_manager.get_setting('pane_states', {
@@ -508,8 +439,8 @@ class EditorTab(QWidget):
         })
         
         # Apply visibility
-        self.snippet_widget.setVisible(states.get('snippets_visible', False))
-        self.browser_widget.setVisible(states.get('browser_visible', False))
+        self.snippet_pane.setVisible(states.get('snippets_visible', False))
+        self.browser_pane.setVisible(states.get('browser_visible', False))
         
         # Apply sizes
         if 'sizes' in states:
@@ -713,14 +644,13 @@ class EditorTab(QWidget):
             
     def update_snippet_list(self):
         """Update snippet list and completer"""
-        if hasattr(self, 'snippet_list'):
-            self.snippet_list.clear()
-            for title in self.snippet_manager.get_snippets():
-                self.snippet_list.addItem(title)
+        if hasattr(self, 'snippet_pane'):
+            snippets = list(self.snippet_manager.get_snippets())
+            self.snippet_pane.set_snippets(snippets)
             self.update_completer_model()
             
-    def insert_snippet(self, item):
-        text = self.snippet_manager.get_snippet(item.text())
+    def insert_snippet(self, snippet_title):
+        text = self.snippet_manager.get_snippet(snippet_title)
         if text:
             self.editor.insertPlainText(text)
             
@@ -852,16 +782,16 @@ class EditorTab(QWidget):
         self._pending_url = url
         
         # Check if browser is visible but too narrow
-        if self.browser_widget.isVisible():
+        if self.browser_pane.isVisible():
             current_sizes = self.splitter.sizes()
             if current_sizes[2] < 300:  # If browser pane is too narrow
                 editor_size = current_sizes[0]
                 new_browser_size = int(editor_size * 0.3)  # 30% of editor width
                 new_editor_size = editor_size - (new_browser_size - current_sizes[2])
                 self.splitter.setSizes([new_editor_size, current_sizes[1], new_browser_size])
-        
+
         # Make sure browser is visible and web view exists
-        if not self.browser_widget.isVisible():
+        if not self.browser_pane.isVisible():
             # Mark browser as opened during focus mode BEFORE toggling
             if self.focus_mode:
                 self.panes_opened_in_focus['browser'] = True
@@ -895,10 +825,10 @@ class EditorTab(QWidget):
 
     def ensure_browser_visible(self):
         """Ensure browser pane is visible"""
-        if not self.browser_widget.isVisible():
-            self.browser_widget.setVisible(True)
+        if not self.browser_pane.isVisible():
+            self.browser_pane.setVisible(True)
             self.settings_manager.save_pane_visibility(
-                self.snippet_widget.isVisible(),
+                self.snippet_pane.isVisible(),
                 True
             )
 
@@ -910,19 +840,19 @@ class EditorTab(QWidget):
         self._pending_url = url
         
         # Check if browser is visible but too narrow
-        if self.browser_widget.isVisible():
+        if self.browser_pane.isVisible():
             current_sizes = self.splitter.sizes()
             if current_sizes[2] < 300:  # If browser pane is too narrow
                 editor_size = current_sizes[0]
                 new_browser_size = int(editor_size * 0.3)  # 30% of editor width
                 new_editor_size = editor_size - (new_browser_size - current_sizes[2])
                 self.splitter.setSizes([new_editor_size, current_sizes[1], new_browser_size])
-        
+
         # If browser is not visible, show it first
-        if not self.browser_widget.isVisible():
+        if not self.browser_pane.isVisible():
             self.toggle_pane("browser")
             return
-        
+
         # If browser is visible but no web view exists, create it
         if not self.web_view:
             self.create_web_view()
@@ -930,7 +860,7 @@ class EditorTab(QWidget):
         # Use existing web view
         self.web_view.stop()
         self.web_view.setUrl(QUrl(url))
-        self.url_bar.setText(url)
+        self.browser_pane.set_url(url)
 
     def search_apnews(self, text):
         """Search AP News in browser pane"""
@@ -940,7 +870,7 @@ class EditorTab(QWidget):
         self._pending_url = url
         
         # If browser is not visible, show it first
-        if not self.browser_widget.isVisible():
+        if not self.browser_pane.isVisible():
             self.toggle_pane("browser")
             return
             
@@ -951,7 +881,7 @@ class EditorTab(QWidget):
         # Use existing web view
         self.web_view.stop()
         self.web_view.setUrl(QUrl(url))
-        self.url_bar.setText(url)
+        self.browser_pane.set_url(url)
         
     def search_google_site_apnews(self, text):
         """Search AP News via Google in browser pane"""
@@ -961,7 +891,7 @@ class EditorTab(QWidget):
         self._pending_url = url
         
         # If browser is not visible, show it first
-        if not self.browser_widget.isVisible():
+        if not self.browser_pane.isVisible():
             self.toggle_pane("browser")
             return
             
@@ -972,7 +902,7 @@ class EditorTab(QWidget):
         # Use existing web view
         self.web_view.stop()
         self.web_view.setUrl(QUrl(url))
-        self.url_bar.setText(url)
+        self.browser_pane.set_url(url)
         
     def save_snippet(self, text):
         """Save selected text as a snippet"""
@@ -982,11 +912,11 @@ class EditorTab(QWidget):
             self.update_snippet_list()
             
     def edit_current_snippet(self):
-        current_item = self.snippet_list.currentItem()
-        if not current_item:
+        current_title = self.snippet_pane.current_snippet()
+        if not current_title:
             return
-            
-        old_title = current_item.text()
+
+        old_title = current_title
         content = self.snippet_manager.get_snippet(old_title)
         
         dialog = SnippetEditorDialog(old_title, content, self)
@@ -999,19 +929,19 @@ class EditorTab(QWidget):
             self.update_snippet_list()
     
     def delete_current_snippet(self):
-        current_item = self.snippet_list.currentItem()
-        if current_item:
-            self.snippet_manager.delete_snippet(current_item.text())
+        current_title = self.snippet_pane.current_snippet()
+        if current_title:
+            self.snippet_manager.delete_snippet(current_title)
             self.update_snippet_list()
 
-    def show_snippet_context_menu(self, position):
+    def show_snippet_context_menu(self, position, global_position):
         menu = QMenu()
-        current_item = self.snippet_list.currentItem()
-        
-        if current_item:
+        current_title = self.snippet_pane.current_snippet()
+
+        if current_title:
             menu.addAction("Edit Snippet", self.edit_current_snippet)
             menu.addAction("Delete Snippet", self.delete_current_snippet)
-            menu.exec_(self.snippet_list.mapToGlobal(position))
+            menu.exec_(global_position)
 
     def update_completer_model(self):
         """Update completer with current snippets"""
@@ -1037,12 +967,17 @@ class EditorTab(QWidget):
         if snippet_content:
             cursor.insertText(snippet_content)
     
-    def navigate_to_url(self):
+    def navigate_to_url(self, url=None):
         """Navigate to URL entered in URL bar"""
-        url = self.url_bar.text().strip()
+        if url is None:
+            url = self.browser_pane.url()
+        else:
+            self.browser_pane.set_url(url)
+
+        url = url.strip()
         if not url:
             return
-            
+
         # Add http:// if no protocol specified
         if not url.startswith(('http://', 'https://')):
             # Check if it's a search query
@@ -1050,46 +985,53 @@ class EditorTab(QWidget):
                 url = f"https://www.google.com/search?q={quote(url)}"
             else:
                 url = 'http://' + url
-        
+
         # Check if browser is visible but too narrow
-        if self.browser_widget.isVisible():
+        if self.browser_pane.isVisible():
             current_sizes = self.splitter.sizes()
             if current_sizes[2] < 300:  # If browser pane is too narrow
                 editor_size = current_sizes[0]
                 new_browser_size = int(editor_size * 0.3)  # 30% of editor width
                 new_editor_size = editor_size - (new_browser_size - current_sizes[2])
                 self.splitter.setSizes([new_editor_size, current_sizes[1], new_browser_size])
-        
+
         # If browser is not visible, show it first
-        if not self.browser_widget.isVisible():
+        if not self.browser_pane.isVisible():
             self._pending_url = url
             self.toggle_pane("browser")
             return
-        
+
         # If browser is visible but no web view exists, create it
         if not self.web_view:
             self.create_web_view()
-        
+
         # Stop any current loading and load new URL
         self.web_view.stop()
         self.web_view.setUrl(QUrl(url))
+        self.browser_pane.set_url(url)
+
+    def handle_browser_back(self):
+        """Handle back navigation requests from the browser pane."""
+        if self.web_view:
+            self.web_view.back()
+
+    def handle_browser_forward(self):
+        """Handle forward navigation requests from the browser pane."""
+        if self.web_view:
+            self.web_view.forward()
 
     def create_web_view(self):
         """Create and set up web view"""
         self.web_view = QWebEngineView()
-        
+
         # Connect all web view signals
         self.web_view.urlChanged.connect(self.update_url)
-        self.web_view.loadStarted.connect(lambda: self.url_bar.setEnabled(False))
-        self.web_view.loadFinished.connect(lambda: self.url_bar.setEnabled(True))
+        self.web_view.loadStarted.connect(lambda: self.browser_pane.set_url_enabled(False))
+        self.web_view.loadFinished.connect(lambda: self.browser_pane.set_url_enabled(True))
         self.web_view.loadFinished.connect(self.update_nav_buttons)
-        
-        # Connect navigation buttons
-        self.back_btn.clicked.connect(self.web_view.back)
-        self.forward_btn.clicked.connect(self.web_view.forward)
-        
+
         # Add to layout
-        self.web_container.layout().addWidget(self.web_view)
+        self.browser_pane.set_web_view(self.web_view)
 
     def update_font(self, font):
         """Update editor font"""
@@ -1135,33 +1077,30 @@ class EditorTab(QWidget):
     def toggle_pane(self, pane_type):
         """Toggle visibility of side panes"""
         if pane_type == "snippets":
-            self.snippet_widget.setVisible(not self.snippet_widget.isVisible())
+            self.snippet_pane.setVisible(not self.snippet_pane.isVisible())
             # If showing snippets, make sure it has reasonable size
-            if self.snippet_widget.isVisible():
+            if self.snippet_pane.isVisible():
                 current_sizes = self.splitter.sizes()
                 if current_sizes[1] < 100:  # If snippet pane is too small
                     editor_size = current_sizes[0]
                     new_snippet_size = int(editor_size * 0.2)  # 20% for snippets
                     new_editor_size = editor_size - new_snippet_size
                     self.splitter.setSizes([new_editor_size, new_snippet_size, current_sizes[2]])
-                    
+
         elif pane_type == "browser":
-            is_visible = self.browser_widget.isVisible()
-            
+            is_visible = self.browser_pane.isVisible()
+
             if is_visible:
                 # If currently visible, hide it and destroy web view
-                self.browser_widget.setVisible(False)
+                self.browser_pane.setVisible(False)
                 if self.web_view:
                     self.web_view.stop()
                     self.web_view.setParent(None)
                     self.web_view.deleteLater()
                     self.web_view = None
-                    
+
                     # Clear the container layout
-                    while self.web_container.layout().count():
-                        item = self.web_container.layout().takeAt(0)
-                        if item.widget():
-                            item.widget().deleteLater()
+                    self.browser_pane.clear_web_view()
             else:
                 # If showing browser, make sure it has reasonable size first
                 current_sizes = self.splitter.sizes()
@@ -1170,9 +1109,9 @@ class EditorTab(QWidget):
                     new_browser_size = int(editor_size * 0.3)
                     new_editor_size = editor_size - new_browser_size
                     self.splitter.setSizes([new_editor_size, current_sizes[1], new_browser_size])
-        
-                self.browser_widget.setVisible(True)
-                
+
+                self.browser_pane.setVisible(True)
+
                 # Create web view and load URL
                 self.create_web_view()
                 if hasattr(self, '_pending_url'):
@@ -1186,9 +1125,9 @@ class EditorTab(QWidget):
         if self.focus_mode:
             if pane_type == "browser":
                 # Only track as opened if we're showing it
-                self.panes_opened_in_focus['browser'] = self.browser_widget.isVisible()
+                self.panes_opened_in_focus['browser'] = self.browser_pane.isVisible()
             elif pane_type == "snippets":
-                self.panes_opened_in_focus['snippets'] = self.snippet_widget.isVisible()
+                self.panes_opened_in_focus['snippets'] = self.snippet_pane.isVisible()
         
         # Save states after toggle
         self.save_pane_states()
@@ -1220,70 +1159,7 @@ class EditorTab(QWidget):
         self.web_view.addAction(paste_action)
         
     def update_url(self, url):
-        self.url_bar.setText(url.toString())
-
-    def setup_browser_toolbar(self):
-        """Setup browser toolbar with navigation controls"""
-        # Browser toolbar
-        toolbar = QWidget()
-        toolbar.setFixedHeight(32)
-        toolbar.setStyleSheet("""
-            QWidget {
-                background: palette(window);
-                border-bottom: 1px solid palette(mid);
-            }
-            QLineEdit {
-                border: 1px solid palette(mid);
-                border-radius: 3px;
-                padding: 2px 8px;
-                background: palette(base);
-                selection-background-color: palette(highlight);
-                margin: 4px;
-            }
-            QPushButton {
-                background: transparent;
-                border: none;
-                border-radius: 3px;
-                padding: 4px;
-                margin: 2px;
-                color: palette(text);
-            }
-            QPushButton:hover {
-                background: palette(highlight);
-                color: palette(highlighted-text);
-            }
-        """)
-        
-        toolbar_layout = QHBoxLayout(toolbar)
-        toolbar_layout.setContentsMargins(4, 0, 4, 0)
-        toolbar_layout.setSpacing(2)
-        
-        # Navigation buttons
-        self.back_btn = QPushButton("←")
-        self.back_btn.setFixedSize(24, 24)
-        self.back_btn.setEnabled(False)  # Initially disabled
-        toolbar_layout.addWidget(self.back_btn)
-        
-        self.forward_btn = QPushButton("→")
-        self.forward_btn.setFixedSize(24, 24)
-        self.forward_btn.setEnabled(False)  # Initially disabled
-        toolbar_layout.addWidget(self.forward_btn)
-        
-        # URL bar
-        self.url_bar = QLineEdit()
-        self.url_bar.setPlaceholderText("Search or enter address")
-        self.url_bar.returnPressed.connect(self.navigate_to_url)
-        toolbar_layout.addWidget(self.url_bar)
-        
-        # Close button
-        close_btn = QPushButton("×")
-        close_btn.setFixedSize(24, 24)
-        close_btn.setFont(QFont("Arial", 14))
-        close_btn.clicked.connect(lambda: self.toggle_pane("browser"))
-        toolbar_layout.addWidget(close_btn)
-        
-        # Add toolbar to browser layout
-        self.browser_widget.layout().addWidget(toolbar)
+        self.browser_pane.set_url(url.toString())
 
     def update_status(self):
         """Update word and character count"""
@@ -1321,8 +1197,8 @@ class EditorTab(QWidget):
         
         # Store current pane states
         self.pre_focus_states = {
-            'snippets_visible': self.snippet_widget.isVisible(),
-            'browser_visible': self.browser_widget.isVisible(),
+            'snippets_visible': self.snippet_pane.isVisible(),
+            'browser_visible': self.browser_pane.isVisible(),
             'sizes': self.splitter.sizes()
         }
         
@@ -1331,8 +1207,8 @@ class EditorTab(QWidget):
         window.tab_widget.tabBar().hide()
         
         # Hide panes
-        self.snippet_widget.hide()
-        self.browser_widget.hide()
+        self.snippet_pane.hide()
+        self.browser_pane.hide()
         
         # Add exit button
         self.exit_focus_btn = QPushButton("Exit Focus Mode", self)
@@ -1383,11 +1259,11 @@ class EditorTab(QWidget):
         # Restore pane states
         if hasattr(self, 'pre_focus_states'):
             browser_should_be_visible = (self.pre_focus_states['browser_visible'] or
-                                       self.browser_widget.isVisible() or
+                                       self.browser_pane.isVisible() or
                                        self.panes_opened_in_focus['browser'])
-            
-            self.snippet_widget.setVisible(self.pre_focus_states['snippets_visible'])
-            self.browser_widget.setVisible(browser_should_be_visible)
+
+            self.snippet_pane.setVisible(self.pre_focus_states['snippets_visible'])
+            self.browser_pane.setVisible(browser_should_be_visible)
             
             # Calculate proper sizes
             total_width = sum(self.pre_focus_states['sizes'])
@@ -1619,8 +1495,8 @@ class EditorTab(QWidget):
     def save_pane_states(self):
         """Save pane visibility and sizes"""
         states = {
-            'snippets_visible': self.snippet_widget.isVisible(),
-            'browser_visible': self.browser_widget.isVisible(),
+            'snippets_visible': self.snippet_pane.isVisible(),
+            'browser_visible': self.browser_pane.isVisible(),
             'sizes': self.splitter.sizes()
         }
         self.settings_manager.save_setting('pane_states', states)
@@ -1852,8 +1728,9 @@ class EditorTab(QWidget):
     def update_nav_buttons(self):
         """Update navigation button states"""
         if self.web_view:
-            self.back_btn.setEnabled(self.web_view.page().action(QWebEnginePage.Back).isEnabled())
-            self.forward_btn.setEnabled(self.web_view.page().action(QWebEnginePage.Forward).isEnabled())
+            back_enabled = self.web_view.page().action(QWebEnginePage.Back).isEnabled()
+            forward_enabled = self.web_view.page().action(QWebEnginePage.Forward).isEnabled()
+            self.browser_pane.set_navigation_enabled(back_enabled, forward_enabled)
 
     def handle_navigation(self, navigation_type, url):
         """Handle navigation requests"""
@@ -1863,7 +1740,4 @@ class EditorTab(QWidget):
 
     def navigate_url(self):
         """Navigate to URL in browser"""
-        url = self.url_bar.text()
-        if not url.startswith(('http://', 'https://')):
-            url = 'https://' + url
-        self.web_view.setUrl(QUrl(url))
+        self.navigate_to_url()

--- a/src/jottr/ui/__init__.py
+++ b/src/jottr/ui/__init__.py
@@ -1,0 +1,1 @@
+"""UI helper widgets for Jottr."""

--- a/src/jottr/ui/editor_layout.py
+++ b/src/jottr/ui/editor_layout.py
@@ -1,0 +1,243 @@
+"""Reusable UI components for the editor layout."""
+
+from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QListWidget,
+    QLineEdit,
+)
+
+
+class EditorPane(QWidget):
+    """Container widget that hosts the main text editor."""
+
+    def __init__(self, editor_widget, parent=None):
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(editor_widget)
+
+
+class SnippetPane(QWidget):
+    """Side pane that lists available snippets."""
+
+    close_requested = pyqtSignal()
+    snippet_activated = pyqtSignal(str)
+    context_menu_requested = pyqtSignal(object, object)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        header = QWidget(self)
+        header.setFixedHeight(28)
+        header.setStyleSheet("""
+            QWidget {
+                background-color: palette(window);
+                padding: 0px;
+                margin: 0px;
+            }
+            QPushButton {
+                border: none;
+                padding: 0px;
+                margin: 0px;
+                color: palette(text);
+            }
+            QPushButton:hover {
+                background-color: palette(highlight);
+                color: palette(highlighted-text);
+            }
+        """)
+
+        header_layout = QHBoxLayout(header)
+        header_layout.setContentsMargins(4, 2, 4, 2)
+        header_layout.setSpacing(4)
+
+        title = QLabel("Snippets", header)
+        title.setStyleSheet("font-weight: bold; padding: 0px; margin: 0px;")
+        header_layout.addWidget(title)
+
+        close_button = QPushButton("×", header)
+        close_button.setFixedSize(20, 20)
+        close_button.clicked.connect(self.close_requested)
+        header_layout.addWidget(close_button)
+
+        layout.addWidget(header)
+
+        self._list_widget = QListWidget(self)
+        self._list_widget.setStyleSheet("""
+            QListWidget {
+                border: none;
+                background-color: palette(base);
+            }
+            QListWidget::item {
+                padding: 4px;
+                border-radius: 2px;
+            }
+            QListWidget::item:selected {
+                background-color: palette(highlight);
+                color: palette(highlighted-text);
+            }
+            QListWidget::item:selected:hover {
+                background-color: palette(highlight);
+                color: palette(highlighted-text);
+            }
+            QListWidget::item:hover:!selected {
+                background-color: palette(alternate-base);
+            }
+        """)
+        self._list_widget.itemDoubleClicked.connect(self._emit_snippet_activated)
+        self._list_widget.customContextMenuRequested.connect(
+            lambda pos: self.context_menu_requested.emit(
+                pos, self._list_widget.mapToGlobal(pos)
+            )
+        )
+        layout.addWidget(self._list_widget)
+
+    def _emit_snippet_activated(self, item):
+        if item:
+            self.snippet_activated.emit(item.text())
+
+    def set_snippets(self, snippets):
+        """Populate the pane with snippet titles."""
+        self._list_widget.clear()
+        self._list_widget.addItems(snippets)
+
+    def current_snippet(self):
+        """Return the currently selected snippet title if any."""
+        current_item = self._list_widget.currentItem()
+        return current_item.text() if current_item else None
+
+    def map_to_global(self, position):
+        """Translate a local position to a global screen position."""
+        return self._list_widget.mapToGlobal(position)
+
+    def set_current_snippet(self, title):
+        """Select the first snippet matching *title*."""
+        matching_items = self._list_widget.findItems(title, Qt.MatchExactly)
+        if matching_items:
+            self._list_widget.setCurrentItem(matching_items[0])
+
+
+class BrowserPane(QWidget):
+    """Side pane that embeds the web browser widget."""
+
+    close_requested = pyqtSignal()
+    navigate_requested = pyqtSignal(str)
+    back_requested = pyqtSignal()
+    forward_requested = pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        toolbar = QWidget(self)
+        toolbar.setFixedHeight(32)
+        toolbar.setStyleSheet("""
+            QWidget {
+                background: palette(window);
+                border-bottom: 1px solid palette(mid);
+            }
+            QLineEdit {
+                border: 1px solid palette(mid);
+                border-radius: 3px;
+                padding: 2px 8px;
+                background: palette(base);
+                selection-background-color: palette(highlight);
+                margin: 4px;
+            }
+            QPushButton {
+                background: transparent;
+                border: none;
+                border-radius: 3px;
+                padding: 4px;
+                margin: 2px;
+                color: palette(text);
+            }
+            QPushButton:hover {
+                background: palette(highlight);
+                color: palette(highlighted-text);
+            }
+        """)
+
+        toolbar_layout = QHBoxLayout(toolbar)
+        toolbar_layout.setContentsMargins(4, 0, 4, 0)
+        toolbar_layout.setSpacing(2)
+
+        self._back_btn = QPushButton("←", toolbar)
+        self._back_btn.setFixedSize(24, 24)
+        self._back_btn.setEnabled(False)
+        self._back_btn.clicked.connect(self.back_requested)
+        toolbar_layout.addWidget(self._back_btn)
+
+        self._forward_btn = QPushButton("→", toolbar)
+        self._forward_btn.setFixedSize(24, 24)
+        self._forward_btn.setEnabled(False)
+        self._forward_btn.clicked.connect(self.forward_requested)
+        toolbar_layout.addWidget(self._forward_btn)
+
+        self._url_bar = QLineEdit(toolbar)
+        self._url_bar.setPlaceholderText("Search or enter address")
+        self._url_bar.returnPressed.connect(self._emit_navigation)
+        toolbar_layout.addWidget(self._url_bar)
+
+        close_btn = QPushButton("×", toolbar)
+        close_btn.setFixedSize(24, 24)
+        close_btn.clicked.connect(self.close_requested)
+        toolbar_layout.addWidget(close_btn)
+
+        layout.addWidget(toolbar)
+
+        self._container = QWidget(self)
+        container_layout = QVBoxLayout(self._container)
+        container_layout.setContentsMargins(0, 0, 0, 0)
+        container_layout.setSpacing(0)
+        layout.addWidget(self._container)
+
+    @property
+    def container_layout(self):
+        return self._container.layout()
+
+    def _emit_navigation(self):
+        self.navigate_requested.emit(self.url())
+
+    def url(self):
+        return self._url_bar.text().strip()
+
+    def set_url(self, url):
+        self._url_bar.setText(url)
+
+    def set_url_enabled(self, enabled):
+        self._url_bar.setEnabled(enabled)
+
+    def set_navigation_enabled(self, back_enabled, forward_enabled):
+        self._back_btn.setEnabled(back_enabled)
+        self._forward_btn.setEnabled(forward_enabled)
+
+    def set_web_view(self, web_view):
+        self.clear_web_view()
+        self.container_layout.addWidget(web_view)
+
+    def clear_web_view(self):
+        layout = self.container_layout
+        while layout.count():
+            item = layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+
+    def has_web_view(self):
+        return self.container_layout.count() > 0
+
+    def focus_url_bar(self):
+        self._url_bar.setFocus()
+


### PR DESCRIPTION
## Summary
- add reusable editor layout widgets (EditorPane, SnippetPane, BrowserPane)
- refactor EditorTab to build the splitter using the new pane classes and expose clean signal wiring

## Testing
- python -m compileall src/jottr

------
https://chatgpt.com/codex/tasks/task_e_68d2ba9590e48328aad3cea6f090f021