### PR TITLE
Refactor spell checking into shared helper

### DIFF
--- a/src/jottr/editor/__init__.py
+++ b/src/jottr/editor/__init__.py
@@ -1,0 +1,5 @@
+"""Editor package utilities."""
+
+from .spellcheck import SpellCheckHighlighter, SpellCheckerHelper
+
+__all__ = ["SpellCheckHighlighter", "SpellCheckerHelper"]

--- a/src/jottr/editor/spellcheck.py
+++ b/src/jottr/editor/spellcheck.py
@@ -1,0 +1,229 @@
+"""Spell checking utilities for the editor widgets."""
+
+import os
+import sys
+from typing import List, Sequence, Set
+
+from PyQt5.QtCore import QRegExp, Qt
+from PyQt5.QtGui import QTextCharFormat, QSyntaxHighlighter
+
+# Ensure bundled vendor libraries (like pyenchant wheels) are discoverable
+VENDOR_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'vendor')
+if os.path.exists(VENDOR_DIR) and VENDOR_DIR not in sys.path:
+    sys.path.insert(0, VENDOR_DIR)
+
+
+class _BaseSpellBackend:
+    """Minimal interface for spell checking backends."""
+
+    def check(self, word: str) -> bool:
+        raise NotImplementedError
+
+    def suggestions(self, word: str) -> Sequence[str]:
+        raise NotImplementedError
+
+    def add(self, word: str) -> None:
+        raise NotImplementedError
+
+
+class _EnchantBackend(_BaseSpellBackend):
+    def __init__(self, language: str):
+        from enchant import Dict, DictNotFoundError  # type: ignore
+
+        try:
+            self._dict = Dict(language)
+        except DictNotFoundError:
+            self._dict = Dict("en_US")
+
+    def check(self, word: str) -> bool:
+        return self._dict.check(word)
+
+    def suggestions(self, word: str) -> Sequence[str]:
+        return self._dict.suggest(word)
+
+    def add(self, word: str) -> None:
+        self._dict.add(word)
+
+
+class _PySpellBackend(_BaseSpellBackend):
+    def __init__(self):
+        from spellchecker import SpellChecker  # type: ignore
+
+        self._spell = SpellChecker()
+
+    def check(self, word: str) -> bool:
+        return word.lower() in self._spell
+
+    def suggestions(self, word: str) -> Sequence[str]:
+        # SpellChecker.candidates returns an unordered set – preserve deterministic order
+        candidates = list(self._spell.candidates(word))
+        return sorted(candidates)
+
+    def add(self, word: str) -> None:
+        self._spell.word_frequency.add(word)
+
+
+class SpellCheckerHelper:
+    """Factory/helper that hides spell-check backend selection and settings access."""
+
+    def __init__(self, settings_manager, language: str = "en_US") -> None:
+        self.settings_manager = settings_manager
+        self.language = language
+        self._backend = self._create_backend(language)
+        self._using_enchant = isinstance(self._backend, _EnchantBackend)
+        self._enabled = bool(self.settings_manager.get_setting('spell_check', True))
+        self._user_words: List[str] = []
+        self._user_words_lower: Set[str] = set()
+        self._sync_user_dictionary()
+
+    @staticmethod
+    def _create_backend(language: str) -> _BaseSpellBackend:
+        try:
+            backend = _EnchantBackend(language)
+            print("Using Enchant for spell checking")
+            return backend
+        except Exception as exc:  # noqa: BLE001 - ensure fallback to pyspellchecker
+            print("Enchant not available, falling back to pyspellchecker:", exc)
+            backend = _PySpellBackend()
+            print("Using pyspellchecker for spell checking")
+            return backend
+
+    @property
+    def using_enchant(self) -> bool:
+        return self._using_enchant
+
+    def is_enabled(self) -> bool:
+        return self._enabled
+
+    def set_enabled(self, enabled: bool) -> None:
+        self._enabled = bool(enabled)
+        self.settings_manager.save_setting('spell_check', self._enabled)
+
+    def _sync_user_dictionary(self) -> None:
+        words = self.settings_manager.get_setting('user_dictionary', []) or []
+        # Preserve insertion order while removing duplicates
+        seen = set()
+        cleaned: List[str] = []
+        for word in words:
+            if not isinstance(word, str):
+                continue
+            normalized = word.strip()
+            if not normalized:
+                continue
+            lowered = normalized.lower()
+            if lowered in seen:
+                continue
+            seen.add(lowered)
+            cleaned.append(normalized)
+        self._user_words = cleaned
+        self._user_words_lower = {word.lower() for word in cleaned}
+        for word in cleaned:
+            self._backend.add(word)
+
+    def get_user_dictionary(self) -> List[str]:
+        self._sync_user_dictionary()
+        return list(self._user_words)
+
+    def add_to_dictionary(self, word: str) -> None:
+        if not isinstance(word, str):
+            return
+        normalized = word.strip()
+        if not normalized:
+            return
+        self._sync_user_dictionary()
+        if normalized.lower() not in self._user_words_lower:
+            updated = list(self._user_words)
+            updated.append(normalized)
+            self.settings_manager.save_setting('user_dictionary', updated)
+            self._user_words = updated
+            self._user_words_lower = {w.lower() for w in updated}
+        self._backend.add(normalized)
+
+    def check_word(self, word: str) -> bool:
+        if not self.is_enabled():
+            return True
+        if not word:
+            return True
+        if word.lower() in self._user_words_lower:
+            return True
+        return self._backend.check(word)
+
+    @staticmethod
+    def is_latin_word(word: str) -> bool:
+        try:
+            word.encode('latin-1')
+            return True
+        except UnicodeEncodeError:
+            return False
+
+    def suggest(self, word: str) -> List[str]:
+        if not self.is_enabled():
+            return []
+        self._sync_user_dictionary()
+        suggestions: List[str] = []
+        seen_lower = set()
+        for dict_word in self._user_words:
+            if dict_word.lower().startswith(word.lower()):
+                suggestions.append(dict_word)
+                seen_lower.add(dict_word.lower())
+        if self.is_latin_word(word):
+            try:
+                backend_suggestions = list(self._backend.suggestions(word))
+            except UnicodeEncodeError:
+                backend_suggestions = []
+            for suggestion in backend_suggestions:
+                lowered = suggestion.lower()
+                if lowered == word.lower():
+                    continue
+                if lowered in seen_lower:
+                    continue
+                suggestions.append(suggestion)
+                seen_lower.add(lowered)
+        return suggestions
+
+
+class SpellCheckHighlighter(QSyntaxHighlighter):
+    """Syntax highlighter that underlines misspelled words using SpellCheckerHelper."""
+
+    def __init__(self, parent, helper: SpellCheckerHelper) -> None:
+        super().__init__(parent)
+        self.helper = helper
+
+    @property
+    def spell_check_enabled(self) -> bool:
+        return self.helper.is_enabled()
+
+    @spell_check_enabled.setter
+    def spell_check_enabled(self, enabled: bool) -> None:
+        self.helper.set_enabled(enabled)
+        self.rehighlight()
+
+    def highlightBlock(self, text: str) -> None:  # noqa: N802 - Qt API
+        if not self.helper.is_enabled():
+            return
+
+        user_dict = set(word.lower() for word in self.helper.get_user_dictionary())
+
+        format_ = QTextCharFormat()
+        format_.setUnderlineColor(Qt.red)
+        format_.setUnderlineStyle(QTextCharFormat.SpellCheckUnderline)
+
+        expression = QRegExp(r"\b\w+\b")
+        index = expression.indexIn(text)
+        while index >= 0:
+            word = expression.cap()
+            length = len(word)
+            if self.helper.is_latin_word(word) and word.lower() not in user_dict:
+                try:
+                    if not self.helper.check_word(word):
+                        self.setFormat(index, length, format_)
+                except UnicodeEncodeError:
+                    pass
+            index = expression.indexIn(text, index + length)
+
+    def suggest(self, word: str) -> List[str]:
+        return self.helper.suggest(word)
+
+    def add_to_dictionary(self, word: str) -> None:
+        self.helper.add_to_dictionary(word)
+        self.rehighlight()

--- a/src/jottr/editor_tab.py
+++ b/src/jottr/editor_tab.py
@@ -9,9 +9,9 @@ if os.path.exists(vendor_dir):
 from PyQt5.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QSplitter,
                             QTextEdit, QListWidget, QInputDialog, QMenu, QFileDialog, QDialog,
                             QToolBar, QAction, QCompleter, QListWidgetItem, QLineEdit, QPushButton, QMessageBox, QLabel, QShortcut, QToolTip)
-from PyQt5.QtCore import Qt, QUrl, QTimer, QStringListModel, QRegExp, QEvent
-from PyQt5.QtGui import (QTextCharFormat, QSyntaxHighlighter, QIcon, QFont, QKeySequence, 
-                        QPainter, QPen, QColor, QFontMetrics, QTextDocument, QTextCursor)
+from PyQt5.QtCore import Qt, QUrl, QTimer, QStringListModel, QEvent
+from PyQt5.QtGui import (QIcon, QFont, QKeySequence, QPainter, QPen, QColor,
+                        QFontMetrics, QTextDocument, QTextCursor)
 from PyQt5.QtWebEngineWidgets import QWebEngineView, QWebEnginePage
 from urllib.parse import quote
 from snippet_editor_dialog import SnippetEditorDialog
@@ -21,130 +21,7 @@ import time
 from theme_manager import ThemeManager
 import hashlib
 
-# Try enchant first, fallback to pyspellchecker
-try:
-    from enchant import Dict, DictNotFoundError
-    USE_ENCHANT = True
-except (ImportError, ModuleNotFoundError) as e:
-    print("Enchant not available, falling back to pyspellchecker:", str(e))
-    from spellchecker import SpellChecker
-    USE_ENCHANT = False
-
-class SpellCheckHighlighter(QSyntaxHighlighter):
-    def __init__(self, parent, settings_manager):
-        super().__init__(parent)
-        self.settings_manager = settings_manager
-        self.spell_check_enabled = True
-        self.USE_ENCHANT = USE_ENCHANT  # Store the global flag
-        
-        try:
-            if self.USE_ENCHANT:
-                self.spell = Dict("en_US")
-                print("Using Enchant for spell checking")
-            else:
-                self.spell = SpellChecker()
-                print("Using pyspellchecker for spell checking")
-        except Exception as e:
-            print(f"Spell checker initialization error: {str(e)}, falling back to pyspellchecker")
-            self.spell = SpellChecker()
-            self.USE_ENCHANT = False
-
-    def check_word(self, word):
-        """Check if a word is spelled correctly"""
-        if not self.spell_check_enabled:
-            return True
-            
-        if self.USE_ENCHANT:
-            return self.spell.check(word)
-        else:
-            # pyspellchecker considers unknown words misspelled
-            return word.lower() in self.spell
-
-    def suggest(self, word):
-        """Get suggestions for a word"""
-        if not self.spell_check_enabled:
-            return []
-            
-        # Get user dictionary
-        user_dict = self.settings_manager.get_setting('user_dictionary', [])
-        
-        # Add matching words from user dictionary first
-        suggestions = [dict_word for dict_word in user_dict 
-                      if dict_word.lower().startswith(word.lower())]
-        
-        # Only get spell checker suggestions for Latin words
-        if self.is_latin_word(word):
-            try:
-                if self.USE_ENCHANT:
-                    spell_suggestions = self.spell.suggest(word)
-                else:
-                    spell_suggestions = self.spell.candidates(word)
-                
-                if spell_suggestions:
-                    # Remove the word itself from suggestions
-                    spell_suggestions = [s for s in spell_suggestions 
-                                      if s.lower() != word.lower()]
-                    suggestions.extend(spell_suggestions)
-            except UnicodeEncodeError:
-                pass
-        
-        # Remove duplicates while preserving order
-        return list(dict.fromkeys(suggestions))
-
-    def add_to_dictionary(self, word):
-        """Add word to user dictionary"""
-        if self.USE_ENCHANT:
-            # Enchant spell checker implementation
-            self.spell.add(word)
-        else:
-            # PySpellChecker implementation
-            self.spell.word_frequency.add(word)
-            # Force a recheck of the document
-            self.highlighter.rehighlight()
-        
-        # Add to user dictionary in settings
-        user_dict = self.settings_manager.get_setting('user_dictionary', [])
-        if word not in user_dict:
-            user_dict.append(word)
-            self.settings_manager.save_setting('user_dictionary', user_dict)
-
-    def highlightBlock(self, text):
-        if not self.spell_check_enabled:
-            return
-
-        # Get user dictionary
-        user_dict = self.settings_manager.get_setting('user_dictionary', [])
-        
-        format = QTextCharFormat()
-        format.setUnderlineColor(Qt.red)
-        format.setUnderlineStyle(QTextCharFormat.SpellCheckUnderline)
-
-        # For each word in the text
-        expression = QRegExp("\\b\\w+\\b")
-        index = expression.indexIn(text)
-        while index >= 0:
-            word = expression.cap()
-            length = len(word)
-            
-            # Only spell check Latin words
-            if self.is_latin_word(word):
-                # Check if word is in user dictionary first
-                if word not in user_dict:
-                    try:
-                        if not self.check_word(word):
-                            self.setFormat(index, length, format)
-                    except UnicodeEncodeError:
-                        pass  # Skip words that can't be encoded
-            
-            index = expression.indexIn(text, index + length)
-
-    def is_latin_word(self, word):
-        """Check if word contains only Latin characters"""
-        try:
-            word.encode('latin-1')
-            return True
-        except UnicodeEncodeError:
-            return False
+from editor.spellcheck import SpellCheckHighlighter, SpellCheckerHelper
 
 class CustomTextEdit(QTextEdit):
     def __init__(self, parent=None):
@@ -207,22 +84,13 @@ class CustomTextEdit(QTextEdit):
         super().keyPressEvent(event)
 
 class CompletingTextEdit(QTextEdit):
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, spell_helper=None):
         super().__init__(parent)
         self.parent_tab = parent
+        self.spell_helper = spell_helper
         self.completion_text = ""
         self.completion_start = None
         self.suppress_completion = False
-        
-        # Initialize spell checker
-        if USE_ENCHANT:
-            try:
-                self.spell_checker = Dict("en_US")
-            except:
-                self.spell_checker = SpellChecker()
-                print("Fallback to pyspellchecker in CompletingTextEdit")
-        else:
-            self.spell_checker = SpellChecker()
 
     def keyPressEvent(self, event):
         """Handle key events"""
@@ -334,19 +202,8 @@ class EditorTab(QWidget):
         self.web_view = None  # Initialize to None
         self.main_window = None  # Initialize main_window to None
         
-        # Add USE_ENCHANT as instance attribute
-        self.USE_ENCHANT = USE_ENCHANT  # Use the module-level variable
-        
-        # Initialize spell checker
-        if self.USE_ENCHANT:
-            try:
-                self.spell_checker = Dict("en_US")
-            except:
-                self.USE_ENCHANT = False  # Fall back if enchant fails
-                self.spell_checker = SpellChecker()
-                print("Fallback to pyspellchecker in EditorTab")
-        else:
-            self.spell_checker = SpellChecker()
+        # Shared spell checking helper
+        self.spell_helper = SpellCheckerHelper(self.settings_manager)
         
         # Setup UI components
         self.setup_ui()
@@ -390,7 +247,7 @@ class EditorTab(QWidget):
         self.splitter = QSplitter(Qt.Horizontal)
         
         # Create text editor with default font
-        self.editor = CompletingTextEdit(self)  # Pass self as parent
+        self.editor = CompletingTextEdit(self, self.spell_helper)  # Pass helper for spell features
         self.editor.setContextMenuPolicy(Qt.CustomContextMenu)
         self.editor.customContextMenuRequested.connect(self.show_context_menu)
         self.update_font(self.current_font)
@@ -399,7 +256,7 @@ class EditorTab(QWidget):
         self.editor.textChanged.connect(self.update_status)
         
         # Create spell checker
-        self.highlighter = SpellCheckHighlighter(self.editor.document(), self.settings_manager)
+        self.highlighter = SpellCheckHighlighter(self.editor.document(), self.spell_helper)
         
         # Add editor to splitter
         self.splitter.addWidget(self.editor)
@@ -819,18 +676,19 @@ class EditorTab(QWidget):
             # Only show spell check options for single words
             if not ' ' in selected_text:
                 # Add spell check suggestions if word is misspelled
-                if self.highlighter.spell_check_enabled:
+                user_dictionary = self.spell_helper.get_user_dictionary()
+                if self.spell_helper.is_enabled():
                     suggestions = self.highlighter.suggest(selected_text)[:7]  # Limit to 7 suggestions
                     if suggestions:
                         menu.addAction("Spelling Suggestions:").setEnabled(False)
                         for suggestion in suggestions:
                             action = menu.addAction(suggestion)
-                            action.triggered.connect(lambda checked, word=suggestion: 
+                            action.triggered.connect(lambda checked, word=suggestion:
                                 self.replace_word(word))
                         menu.addSeparator()
-                
+
                 # Add to dictionary option if not already in it
-                if selected_text not in self.settings_manager.get_setting('user_dictionary', []):
+                if selected_text.lower() not in {w.lower() for w in user_dictionary}:
                     add_action = menu.addAction("Add to Dictionary")
                     add_action.triggered.connect(lambda: self.add_to_dictionary(selected_text))
                     menu.addSeparator()
@@ -878,20 +736,8 @@ class EditorTab(QWidget):
 
     def add_to_dictionary(self, word):
         """Add word to user dictionary"""
-        if self.USE_ENCHANT:
-            # Enchant spell checker implementation
-            self.spell_checker.add(word)
-        else:
-            # PySpellChecker implementation
-            self.spell_checker.word_frequency.add(word)
-            # Force a recheck of the document
-            self.highlighter.rehighlight()
-        
-        # Add to user dictionary in settings
-        user_dict = self.settings_manager.get_setting('user_dictionary', [])
-        if word not in user_dict:
-            user_dict.append(word)
-            self.settings_manager.save_setting('user_dictionary', user_dict)
+        self.spell_helper.add_to_dictionary(word)
+        self.highlighter.rehighlight()
 
     def ensure_browser_visible(self):
         """Ensure browser pane is visible"""
@@ -1608,7 +1454,7 @@ class EditorTab(QWidget):
                         suggestions.append(('snippet', title))
 
             # Get dictionary suggestions
-            user_dict = self.settings_manager.get_setting('user_dictionary', [])
+            user_dict = self.spell_helper.get_user_dictionary()
             for word in user_dict:
                 if word.lower().startswith(current_word.lower()) and word.lower() != current_word.lower():
                     suggestions.append(('word', word))


### PR DESCRIPTION
## Summary
- add a spell checking helper module that wraps enchant/pyspellchecker selection, user dictionary sync, and suggestions
- update the editor tab and completing text edit to consume the shared helper for spell checking and dictionary actions
- export the helper and highlighter from the new editor package for reuse

## Testing
- python -m compileall src/jottr

------
https://chatgpt.com/codex/tasks/task_e_68d2ba9b761c83289411bf87295c7112